### PR TITLE
hostToPing sollte chaostreff.vpn.zekjur.net sein

### DIFF
--- a/frank/raumbang.go
+++ b/frank/raumbang.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const hostToPing = "lolpizza.de"
+const hostToPing = "chaostreff.vpn.zekjur.net"
 
 // only answer !raum from this channel
 const bangRaumChannel = "#chaos-hd"


### PR DESCRIPTION
lolpizza.de resolved auf eine interne IP-Adresse.
