### PR TITLE
Add no spoiler command to urifind

### DIFF
--- a/frank/urifind.go
+++ b/frank/urifind.go
@@ -38,6 +38,8 @@ var newlineReplacer = regexp.MustCompile(`\s+`)
 
 var ignoreDomainsRegex = regexp.MustCompile(`^http://p\.nnev\.de`)
 
+var noSpoilerRegex = regexp.MustCompile(`don't spoiler`)
+
 func UriFind(conn *irc.Conn, line *irc.Line) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -46,6 +48,10 @@ func UriFind(conn *irc.Conn, line *irc.Line) {
 	}()
 
 	msg := line.Args[1]
+
+	if noSpoilerRegex.MatchString(msg) {
+		return
+	}
 
 	urls := extract(msg)
 


### PR DESCRIPTION
If anyone posts a url together with the text "don't spoiler", frank will
not post it's title.
