### PR TITLE
Removed „Verified Twitter Account“ Text

### DIFF
--- a/frank/urifind.go
+++ b/frank/urifind.go
@@ -182,6 +182,7 @@ func titleParseHtml(r io.Reader) (string, string) {
 	title := ""
 	tweetText := ""
 	tweetUser := ""
+	tweetUserVerified := ""
 	tweetPicUrl := ""
 
 	var f func(*html.Node)
@@ -209,6 +210,11 @@ func titleParseHtml(r io.Reader) (string, string) {
 			return
 		}
 
+		if tweetUserVerified == "" && hasClass(n, "verified") {
+			tweetUserVerified = extractText(n)
+			return
+		}
+
 		isMedia := hasClass(n, "media") || hasClass(n, "media-thumbnail")
 		if tweetPicUrl == "" && isMedia && !hasClass(n, "profile-picture") {
 			attrVal := getAttr(n, "data-url")
@@ -230,6 +236,7 @@ func titleParseHtml(r io.Reader) (string, string) {
 	tweet := ""
 	if tweetText != "" {
 		tweetText = twitterPicsRegex.ReplaceAllString(tweetText, "")
+		tweetUser = strings.Replace(tweetUser, tweetUserVerified, "", 1)
 		tweetUser = strings.Replace(tweetUser, "@", "(@", 1) + "): "
 		tweet = tweetUser + tweetText + " " + tweetPicUrl
 		tweet = clean(tweet)

--- a/frank/urifind_test.go
+++ b/frank/urifind_test.go
@@ -33,6 +33,8 @@ func TestTitleGet(t *testing.T) {
 	samples["https://twitter.com/Perspective_pic/status/400356645504831489"] = "Perspective Pictures (@Perspective_pic): Sorry but this without a doubt the greatest thing ever seen on an air duct https://pbs.twimg.com/media/BY5aP2RIQAAWPl1.jpg:large"
 	samples["https://twitter.com/quityourjrob/status/405438033853313025/photo/1"] = "Joanna Robinson (@jowrotethis): How to tell if a toy is for boys or girls. https://pbs.twimg.com/media/BaBnvl5CYAAyYzm.jpg:large"
 	samples["https://twitter.com/rechelon/status/431242278221275137"] = "William Gillis (@rechelon): @SebastosPublius @jfsmith23 Yep. Godesky had gathered a large following back then and was more sane than Zerzan & less terrible than Jensen."
+	samples["https://twitter.com/thejeremyvine/status/433607774375649280"] = "Jeremy Vine (@theJeremyVine): The internet was invented so someone could ask this question - and get an answer: https://pbs.twimg.com/media/BgR7-TQCIAAE4fm.jpg:large"
+	samples["http://twitter.com/thejeremyvine/status/433607774375649280"] = "Jeremy Vine (@theJeremyVine): The internet was invented so someone could ask this question - and get an answer: https://pbs.twimg.com/media/BgR7-TQCIAAE4fm.jpg:large"
 
 	for url, title := range samples {
 		x, _, _ := TitleGet(url)


### PR DESCRIPTION
This removes the „Verified Account“ (in different languages) from franks Tweet-Posts.

Please review the commit and bug me if something is broken.
