### PR TITLE
fix lmgtfy url

### DIFF
--- a/lmgtfy.go
+++ b/lmgtfy.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const googUrl = "http://googl.com/search?btnI=1&q="
+const googUrl = "http://google.com/search?btnI=1&q="
 
 // regex that matches lmgtfy requests
 var lmgtfyMatcher = regexp.MustCompile(`^(?:[\d\pL._-]+: )?lmgtfy:? (.+)`)


### PR DESCRIPTION
```
13:03 <someone_nice> someone_who_didnt_google: lmgtfy: Das internet ist eine Spielerei für Computerfreaks
13:03 <@frank> [LMGTFY] 
               http://googl.com/search?btnI=1&q=Das+internet+ist+eine+Spielerei+f%C3%BCr+Computerfreaks
```
should be `google.com` instead of `googl.com`.

though … looking at it, I'm wondering if it's intended to be just slightly wrong?