### PR TITLE
lmgtfy: fix google URL and refactor…

### DIFF
--- a/lmgtfy.go
+++ b/lmgtfy.go
@@ -1,7 +1,11 @@
 package main
 
 import (
-	"log"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -9,10 +13,7 @@ import (
 	"time"
 )
 
-const googUrl = "http://googl.com/search?btnI=1&q="
-
-// regex that matches lmgtfy requests
-var lmgtfyMatcher = regexp.MustCompile(`^(?:[\d\pL._-]+: )?lmgtfy:? (.+)`)
+var ErrNoResponse = errors.New("extractPost did not return a response")
 
 func runnerLmgtfy(parsed Message) {
 	tgt := Target(parsed)
@@ -23,37 +24,86 @@ func runnerLmgtfy(parsed Message) {
 		return
 	}
 
-	post := extractPost(msg)
-
-	if post != "" {
-		Privmsg(tgt, post)
+	reply, err := lmgtfyReplyFor(msg)
+	if err != nil {
+		if err == ErrNoResponse {
+			return
+		}
+		Privmsg(tgt, fmt.Sprintf("Error: %v", err))
+		return
 	}
+	Privmsg(tgt, fmt.Sprintf("[LMGTFY] %s", reply))
 }
 
-// returns the String to be posted
-func extractPost(msg string) string {
-	if !lmgtfyMatcher.MatchString(msg) {
-		return ""
-	}
-
-	match := lmgtfyMatcher.FindStringSubmatch(msg)
-
-	if len(match) < 2 {
-		log.Printf("WTF: lmgtfy regex match didn’t have enough parts")
-		return ""
-	}
-
-	u := googUrl + url.QueryEscape(match[1])
-	c := http.Client{Timeout: 10 * time.Second}
-	t, lastUrl, err := TitleGet(&c, u)
-
-	post := ""
-
+func googleLucky(ctx context.Context, query string) (*url.URL, error) {
+	u, err := url.Parse("https://www.google.com/search?btnI=1&q=")
 	if err != nil {
-		post = "[LMGTFY] " + lastUrl
-	} else {
-		post = "[LMGTFY] " + t + " @ " + lastUrl
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("q", query)
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "frank IRC Bot")
+
+	cl := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Only follow redirects within Google.
+			if !strings.Contains(req.URL.Host, ".google.") {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+	resp, err := cl.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		// Exhaust r.Body to prevent Keep-Alive breakage
+		ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+	}()
+
+	if got, want := resp.StatusCode, http.StatusFound; got != want {
+		// get a few characters (to not exceed the RobustIRC message
+		// length and IRC netiquette) of the body into the error
+		// message
+		body, _ := ioutil.ReadAll(&io.LimitedReader{R: resp.Body, N: 200})
+		return nil, fmt.Errorf("unexpected HTTP status code for %q: got %d, want %d. body: %s", u.String(), got, want, string(body))
 	}
 
-	return post
+	return resp.Location()
+}
+
+var lmgtfyMatcher = regexp.MustCompile(`^(?:[\d\pL._-]+: )?lmgtfy:? (.+)`)
+
+func lmgtfyReplyFor(msg string) (string, error) {
+	match := lmgtfyMatcher.FindStringSubmatch(msg)
+	if match == nil {
+		return "", ErrNoResponse
+	}
+	if len(match) < 2 {
+		return "", fmt.Errorf("could not extract lmgtfy query from %q", msg)
+	}
+	query := match[1]
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+	u, err := googleLucky(ctx, query)
+	if err != nil {
+		return "", fmt.Errorf("Error googling %q: %v", query, err)
+	}
+	result := u.String()
+
+	c := &http.Client{Timeout: 10 * time.Second}
+	if title, _, err := TitleGet(c, result); err == nil {
+		return fmt.Sprintf("%s @ %s", title, result), nil
+	}
+
+	// Fall back to the result URL
+	return result, nil
 }

--- a/lmgtfy_test.go
+++ b/lmgtfy_test.go
@@ -1,26 +1,31 @@
 package main
 
 import (
-	"strings"
+	"context"
 	"testing"
+	"time"
 )
 
-func TestExtractPost(t *testing.T) {
-	// Comment out when testing. Google changes results regularly, making this system test failing too often
-	return
-
-	var samples = make(map[string]string)
-	samples["xeen: lmgtfy: xeens deine mudda nacktbilder"] = "[LMGTFY] frank/lmgtfy_test.go at master · breunigs/frank · GitHub @ https://github.com/breunigs/frank/blob/master/frank/lmgtfy_test.go" //taken from the channel
-	samples["lmgtfy: google maps"] = "[LMGTFY] Google Maps @ https://"
-	samples["lmgtfy: yrden my mail setup"] = "[LMGTFY] yrden my mail setup - Google Search @ http://www.google.com/search?btnI=1&q=yrden+my+mail+setup"
-	samples["buaitrnosups"] = ""
-	samples["warum funktioniert lmgtfy nicht?"] = ""
-	samples["lmgtfy lmgtfy"] = "[LMGTFY] Let me google that for you @ http://lmgtfy.com/"
-
-	for msg, post := range samples {
-		x := extractPost(msg)
-		if !strings.HasPrefix(x, post) {
-			t.Errorf("extractPost(%v)\n GOT: ||%v||\nWANT: ||%v||", msg, x, post)
+func TestGoogleLucky(t *testing.T) {
+	const query = "Apple"
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	u, err := googleLucky(ctx, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var okay bool
+	possibilities := []string{
+		"www.apple.com",
+		"apple.com",
+	}
+	for _, p := range possibilities {
+		if u.Host == p {
+			okay = true
+			break
 		}
+	}
+	if !okay {
+		t.Fatalf("unexpected Host field of query %q result %q: got %q, want one of %v", query, u.String(), u.Host, possibilities)
 	}
 }


### PR DESCRIPTION
…such that:

• errors are reported to IRC when they occur

• timeouts are set via contexts, so that we can set a global per-reply
  timeout in a single place in a future refactoring

• A testcase verifies that Google’s I’m Feeling Lucky functionality
  works as expected. The previous attempt at a testcase verified the
  result URL’s title, which would change frequently enough that the
  testcase was disabled. The new test case checks whether searching
  “Apple” leads to a URL with a hostname portion of www.apple.com or
  apple.com, which will likely be true for the foreseeable future.

• The regexp is only evaluated once, which likely has no measurable
  impact but is cleaner nevertheless :).

Surrounding code has been changed to be more idiomatic where it made
sense. Functions have been renamed to make splitting up into multiple
packages easier.