### PR TITLE
Fix termine query by casting NOW() to date

### DIFF
--- a/topicchanger.go
+++ b/topicchanger.go
@@ -132,7 +132,7 @@ SELECT
 FROM termine
 LEFT JOIN vortraege
 ON termine.date = vortraege.date
-WHERE termine.date >= NOW()
+WHERE termine.date >= NOW()::date
 ORDER BY termine.date ASC
 LIMIT 1
 `


### PR DESCRIPTION
Without this explicit cast, PostgreSQL casts termine.date to timestamp, and the
equals part of the >= operator fails.

fixes #41